### PR TITLE
Add async retrier

### DIFF
--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -404,6 +404,8 @@ class Exchange(object):
         for tick in tickers:
             if tick[0] == pair:
                 data.extend(tick[1])
+        # Sort data again after extending the result - above calls return in "async order" order
+        data = sorted(data, key=lambda x: x[0])
         logger.info("downloaded %s with length %s.", pair, len(data))
         return data
 

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -22,10 +22,6 @@ def get_mock_coro(return_value):
     return Mock(wraps=mock_coro)
 
 
-async def async_load_markets():
-    return {}
-
-
 def ccxt_exceptionhandlers(mocker, default_conf, api_mock, fun, mock_ccxt_fun, **kwargs):
     with pytest.raises(TemporaryError):
         api_mock.__dict__[mock_ccxt_fun] = MagicMock(side_effect=ccxt.NetworkError)

--- a/freqtrade/tests/exchange/test_exchange.py
+++ b/freqtrade/tests/exchange/test_exchange.py
@@ -45,7 +45,7 @@ async def async_ccxt_exception(mocker, default_conf, api_mock, fun, mock_ccxt_fu
         api_mock.__dict__[mock_ccxt_fun] = MagicMock(side_effect=ccxt.NetworkError)
         exchange = get_patched_exchange(mocker, default_conf, api_mock)
         await getattr(exchange, fun)(**kwargs)
-    assert api_mock.__dict__[mock_ccxt_fun].call_count == 1
+    assert api_mock.__dict__[mock_ccxt_fun].call_count == API_RETRY_COUNT + 1
 
     with pytest.raises(OperationalException):
         api_mock.__dict__[mock_ccxt_fun] = MagicMock(side_effect=ccxt.BaseError)


### PR DESCRIPTION
Adds a @retrier decorator working in async.

Also accidentaly found a problem with data not beeing sorted from download/backtest-download.

to test, best run download-script against kraken without rate-limit - get's ddos-protection within 5 seconds or so ... 

